### PR TITLE
Update for Contributor Covenant 1.4.1

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,9 +5,9 @@
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-education, socio-economic status, nationality, personal appearance, race,
-religion, or sexual identity and orientation.
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 

--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+1.004001 ????-??-??
+ - Version of module matches Contributor Covenant version
+ - Include changes in 1.4.1 minor release of Contributor Covenant
+
 0.02 2018-06-19
  - Let users have a copy of COC in GitHub
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ You can add following lines to your dist.ini as well.
 Note that this plugin will prune other CODE\_OF\_CONDUCT.md files, to
 avoid multiple CODE\_OF\_CONDUCT.md preventing the build.
 
+The version of this module will match the version of the Contributor
+Covenant used.  For instance, version 1.004001 will use Contributor
+Covenant version 1.4.1.
+
 # AUTHOR
 
 Kivanc Yazan `<kyzn at cpan.org>`

--- a/dist.ini
+++ b/dist.ini
@@ -1,7 +1,7 @@
 name    = Dist-Zilla-Plugin-ContributorCovenant
 author  = Kivanc Yazan <kyzn@cpan.org>
 license = Perl_5
-version = 0.02
+version = 1.004001  ; 1.4.1
 copyright_holder = Kivanc Yazan
 
 [@Filter]

--- a/lib/Dist/Zilla/Plugin/ContributorCovenant.pm
+++ b/lib/Dist/Zilla/Plugin/ContributorCovenant.pm
@@ -26,6 +26,10 @@ You can add following lines to your dist.ini as well.
 Note that this plugin will prune other CODE_OF_CONDUCT.md files, to
 avoid multiple CODE_OF_CONDUCT.md preventing the build.
 
+The version of this module will match the version of the Contributor
+Covenant used.  For instance, version 1.004001 will use Contributor
+Covenant version 1.4.1.
+
 =cut
 
 use warnings;
@@ -103,9 +107,9 @@ sub contributor_covenant_template {
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-education, socio-economic status, nationality, personal appearance, race,
-religion, or sexual identity and orientation.
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 


### PR DESCRIPTION
There was a minor change made upstream for the Contributor Covenant between 1.4 and 1.4.1.  This pulls that change in.

This patch also sets the module version to 1.004001 - to correspond with 1.4.1 of the upstream, making it easier for people to include exactly the version they want.  If you want these changes separated, or if there is anything I can do that can make them more respectful of your distribution, please let me know.  Thanks!